### PR TITLE
[fix]: Add request payload DTO to validate incoming data from telex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/platform-express": "^10.0.0",
         "@types/winston": "^2.4.4",
         "agent": "@mastra/core/agent",
+        "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
@@ -8343,11 +8344,15 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "license": "MIT"
     },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
     "node_modules/class-validator": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
       "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
-      "license": "MIT",
       "dependencies": {
         "@types/validator": "^13.11.8",
         "libphonenumber-js": "^1.10.53",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@types/winston": "^2.4.4",
     "agent": "@mastra/core/agent",
+    "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",

--- a/src/email-marketer/dto/req-payload.dto.ts
+++ b/src/email-marketer/dto/req-payload.dto.ts
@@ -1,0 +1,34 @@
+import { Type } from 'class-transformer';
+import { IsBoolean, IsString, ValidateNested } from 'class-validator';
+
+export class SettingsDto {
+  @IsString()
+  default: string;
+
+  @IsString()
+  label: string;
+
+  @IsBoolean()
+  required: boolean;
+
+  @IsString()
+  type: string;
+}
+
+export class ReqPayloadDto {
+  @IsString()
+  message: string;
+
+  @IsString()
+  channel_id: string;
+
+  @IsString()
+  thread_id: string;
+
+  @IsString()
+  org_id: string;
+
+  @ValidateNested({ each: true })
+  @Type(() => SettingsDto)
+  settings: SettingsDto[];
+}

--- a/src/email-marketer/email-marketer.controller.ts
+++ b/src/email-marketer/email-marketer.controller.ts
@@ -17,28 +17,17 @@ export class EmailMarketerController {
 
   @Post('generate')
   async sendEmail(@Body() reqBody: ReqPayloadDto) {
-    const body = reqBody;
-    logger.info(`Received request body => ${JSON.stringify(body)}`);
-
-    // console.log(JSON.stringify({ body: body }));
-    logger.info({ message: body.message });
     try {
-      if (!body.message) {
+      logger.info(`Received request body => ${JSON.stringify(reqBody)}`);
+
+      if (!reqBody.message) {
         throw new Error('Prompt is required');
       }
 
-      // const webhookUrl = body.settings.find(
-      //   (s: any) => s.label === 'webhook_url',
-      // ).default;
-
-      // if (!body.settings || !webhookUrl) {
-      //   throw new Error('Webhook URL is required');
-      // }
-
-      const webhookUrl = '0195ab80-a186-75cf-97d2-1efff827ba2e';
+      const channelId = reqBody.channel_id;
 
       const message = await this.emailMarketerService.generateEmailWithMastra(
-        body.message,
+        reqBody.message,
       );
 
       logger.info(
@@ -47,7 +36,7 @@ export class EmailMarketerController {
 
       await this.emailMarketerService.sendGeneratedEmailToTelex(
         message,
-        webhookUrl,
+        channelId,
       );
 
       return { message: 'Email successfully sent to Telex' };
@@ -87,53 +76,10 @@ export class EmailMarketerController {
             required: true,
             default: '10',
           },
-          {
-            label: 'webhook_url',
-            type: 'text',
-            required: true,
-            default: 'Write your webhook url here',
-          },
         ],
         target_url: `https://mastraaiemailagent.onrender.com/email-marketer/generate`,
         tick_url: `https://mastraaiemailagent.onrender.com/email-marketer/generate/integration-config`,
       },
     };
   }
-
-  // @Get('integration-config')
-  // async getIntegrationConfig() {
-  //   console.log(`Integration Config`);
-
-  //   return {
-  //     data: {
-  //       date: {
-  //         created_at: '2025-03-12',
-  //         updated_at: '2025-03-13',
-  //       },
-  //       descriptions: {
-  //         app_name: 'Email Marketing Agent',
-  //         app_description:
-  //           'An AI-powered email marketing agent designed to generate engaging and personalized marketing emails',
-  //         app_logo: 'https://img.icons8.com/nolan/64/slack-new.png',
-  //         app_url: 'https://6dw8m2pj-3150.uks1.devtunnels.ms',
-  //         background_color: '#fff',
-  //       },
-  //       is_active: true,
-  //       integration_type: 'modifier',
-  //       integration_category: 'Marketing Automation',
-  //       key_features: ['Email Generation', 'Prompt Response', 'AI-Powered'],
-  //       author: 'Diligwe',
-  //       settings: [
-  //         {
-  //           label: 'Duration',
-  //           type: 'number',
-  //           required: true,
-  //           default: '10',
-  //         },
-  //       ],
-  //       target_url: `https://6dw8m2pj-3150.uks1.devtunnels.ms/email-marketer/generate`,
-  //       tick_url: `https://6dw8m2pj-3150.uks1.devtunnels.ms/email-marketer/integration-config`,
-  //     },
-  //   };
-  // }
 }

--- a/src/email-marketer/email-marketer.controller.ts
+++ b/src/email-marketer/email-marketer.controller.ts
@@ -9,28 +9,33 @@ import {
 import { EmailMarketerService } from './email-marketer.service';
 import { ENV_CONFIG } from '../utils/envConfig';
 import logger from 'src/config/logger';
+import { ReqPayloadDto } from './dto/req-payload.dto';
 
 @Controller('email-marketer')
 export class EmailMarketerController {
   constructor(private readonly emailMarketerService: EmailMarketerService) {}
 
   @Post('generate')
-  async sendEmail(@Body() body: any) {
-    logger.info(`Received request body => ${body}`);
+  async sendEmail(@Body() reqBody: ReqPayloadDto) {
+    const body = reqBody;
+    logger.info(`Received request body => ${JSON.stringify(body)}`);
 
-    logger.info({ prompt: body.prompt, message: body.message });
+    // console.log(JSON.stringify({ body: body }));
+    logger.info({ message: body.message });
     try {
-      if (!body.prompt && !body.message) {
+      if (!body.message) {
         throw new Error('Prompt is required');
       }
 
-      const webhookUrl = body.settings.find(
-        (s: any) => s.label === 'webhook_url',
-      ).default;
+      // const webhookUrl = body.settings.find(
+      //   (s: any) => s.label === 'webhook_url',
+      // ).default;
 
-      if (!body.settings || !webhookUrl) {
-        throw new Error('Webhook URL is required');
-      }
+      // if (!body.settings || !webhookUrl) {
+      //   throw new Error('Webhook URL is required');
+      // }
+
+      const webhookUrl = '0195ab80-a186-75cf-97d2-1efff827ba2e';
 
       const message = await this.emailMarketerService.generateEmailWithMastra(
         body.message,
@@ -54,6 +59,8 @@ export class EmailMarketerController {
 
   @Get('integration-config')
   async getIntegrationConfig() {
+    logger.info(`Integration Config`);
+
     return {
       data: {
         date: {
@@ -92,4 +99,41 @@ export class EmailMarketerController {
       },
     };
   }
+
+  // @Get('integration-config')
+  // async getIntegrationConfig() {
+  //   console.log(`Integration Config`);
+
+  //   return {
+  //     data: {
+  //       date: {
+  //         created_at: '2025-03-12',
+  //         updated_at: '2025-03-13',
+  //       },
+  //       descriptions: {
+  //         app_name: 'Email Marketing Agent',
+  //         app_description:
+  //           'An AI-powered email marketing agent designed to generate engaging and personalized marketing emails',
+  //         app_logo: 'https://img.icons8.com/nolan/64/slack-new.png',
+  //         app_url: 'https://6dw8m2pj-3150.uks1.devtunnels.ms',
+  //         background_color: '#fff',
+  //       },
+  //       is_active: true,
+  //       integration_type: 'modifier',
+  //       integration_category: 'Marketing Automation',
+  //       key_features: ['Email Generation', 'Prompt Response', 'AI-Powered'],
+  //       author: 'Diligwe',
+  //       settings: [
+  //         {
+  //           label: 'Duration',
+  //           type: 'number',
+  //           required: true,
+  //           default: '10',
+  //         },
+  //       ],
+  //       target_url: `https://6dw8m2pj-3150.uks1.devtunnels.ms/email-marketer/generate`,
+  //       tick_url: `https://6dw8m2pj-3150.uks1.devtunnels.ms/email-marketer/integration-config`,
+  //     },
+  //   };
+  // }
 }

--- a/src/email-marketer/email-marketer.service.ts
+++ b/src/email-marketer/email-marketer.service.ts
@@ -43,8 +43,8 @@ export class EmailMarketerService {
     }
   }
 
-  async sendGeneratedEmailToTelex(email: string, webhook_url: string) {
-    const url = `https://ping.telex.im/v1/webhooks/${webhook_url}`;
+  async sendGeneratedEmailToTelex(email: string, channelId: string) {
+    const url = `https://ping.telex.im/v1/webhooks/${channelId}`;
     logger.info('Sending email to Telex:', { email });
 
     const data = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,15 +3,19 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ENV_CONFIG } from './utils/envConfig';
 import logger from './config/logger';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   app.enableCors();
 
-  const port = ENV_CONFIG.PORT || 3000;
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+
+  const port = 3150;
   await app.listen(port, '0.0.0.0', () => {
     logger.info(`Application running on port ${port}`);
+    console.log(`Application running on port ${port}`);
   });
 }
 bootstrap();

--- a/src/utils/mastra/mastra-ai.ts
+++ b/src/utils/mastra/mastra-ai.ts
@@ -7,9 +7,7 @@ import { ENV_CONFIG } from '../envConfig';
 import logger from 'src/config/logger';
 
 const groq = createGroq({
-  apiKey:
-    ENV_CONFIG.GROQ_AI_API_KEY ||
-    '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',
+  apiKey: ENV_CONFIG.GROQ_AI_API_KEY,
 });
 
 const emailAgent = new Agent({

--- a/src/utils/mastra/mastra-ai.ts
+++ b/src/utils/mastra/mastra-ai.ts
@@ -7,7 +7,9 @@ import { ENV_CONFIG } from '../envConfig';
 import logger from 'src/config/logger';
 
 const groq = createGroq({
-  apiKey: ENV_CONFIG.GROQ_AI_API_KEY,
+  apiKey:
+    ENV_CONFIG.GROQ_AI_API_KEY ||
+    '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',
 });
 
 const emailAgent = new Agent({


### PR DESCRIPTION
This pull request includes changes to the `email-marketer` module to dynamically use the `channel_id` of different channels that communicates with the integration.

Changes made:
- Added a `req-payload.dto.ts` file that includes DTOs for incoming request payload from telex and validations decorators from class-validator to validate the datatypes and structure of the payload

- Removed the settings that requires manually inputting the `channel_id` of the channel